### PR TITLE
Fixed display problems due to Git's Markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 _site
+.project

--- a/_posts/2013-04-18-user_guide.markdown
+++ b/_posts/2013-04-18-user_guide.markdown
@@ -66,7 +66,7 @@ If you need to set custom JVM options (such as memory settings, system propertie
 ## Pro Tips
 
 You can run all the tests in a project (and generally 'reset' things) in Infinitest-Eclipse by cleaning the project.  
-You can view the stack trace for a failure from the quick fix menu.
+You can view the stack trace for a failure from the quick fix menu
 
 By default, IntelliJ does not compile classes automatically like Eclipse. You can obtain the same behaviour by checking the box "Make project automatically" in "Settings > Compiler". This way, you tests will be executed automagically without having anything to do.
 
@@ -76,11 +76,11 @@ By default, IntelliJ does not compile classes automatically like Eclipse. You ca
 
 If you're running Eclipse, ensure that:
 
-You've resolved any compiler or other workspace errors.
-The "Continuously Test" option in the Infinitest preferences (under Window->Preferences) is checked.
-"Build Automatically" under the "Project" menu is checked.
-The test is not being filtered by an entry in the `infinitest.filters` file in the root directory of the project.
-If you're using a custom builder (like AspectJ) make sure you have the appropriate plugins installed.
+You've resolved any compiler or other workspace errors
+The "Continuously Test" option in the Infinitest preferences (under Window->Preferences) is checked
+"Build Automatically" under the "Project" menu is checked
+The test is not being filtered by an entry in the `infinitest.filters` file in the root directory of the project
+If you're using a custom builder (like AspectJ) make sure you have the appropriate plugins installed
 
 If you're using IntelliJ:
 

--- a/_posts/2013-04-18-user_guide.markdown
+++ b/_posts/2013-04-18-user_guide.markdown
@@ -65,10 +65,10 @@ If you need to set custom JVM options (such as memory settings, system propertie
 
 ## Pro Tips
 
-You can run all the tests in a project (and generally 'reset' things) in Infinitest-Eclipse by cleaning the project.
+You can run all the tests in a project (and generally 'reset' things) in Infinitest-Eclipse by cleaning the project.  
 You can view the stack trace for a failure from the quick fix menu
 
-By default, IntelliJ does not compile classes automatically like Eclipse. You can obtain the same behaviour by checking the box "Make project automatically" in "Settings | Compiler". This way, you tests will be executed automagically without having anything to do.
+By default, IntelliJ does not compile classes automatically like Eclipse. You can obtain the same behaviour by checking the box "Make project automatically" in `Settings->Compiler`. This way, you tests will be executed automagically without having anything to do.
 
 ## Common Problems
 
@@ -76,11 +76,11 @@ By default, IntelliJ does not compile classes automatically like Eclipse. You ca
 
 If you're running Eclipse, ensure that:
 
-You've resolved any compiler or other workspace errors
-The "Continuously Test" option in the Infinitest preferences (under Window->Preferences) is checked
-"Build Automatically" under the "Project" menu is checked
-The test is not being filtered by an entry in the `infinitest.filters` file in the root directory of the project
-If you're using a custom builder (like AspectJ) make sure you have the appropriate plugins installed
+You've resolved any compiler or other workspace errors.
+The "Continuously Test" option in the Infinitest preferences (under Window->Preferences) is checked.
+"Build Automatically" under the "Project" menu is checked.
+The test is not being filtered by an entry in the `infinitest.filters` file in the root directory of the project.
+If you're using a custom builder (like AspectJ) make sure you have the appropriate plugins installed.
 
 If you're using IntelliJ:
 

--- a/_posts/2013-04-18-user_guide.markdown
+++ b/_posts/2013-04-18-user_guide.markdown
@@ -65,10 +65,10 @@ If you need to set custom JVM options (such as memory settings, system propertie
 
 ## Pro Tips
 
-You can run all the tests in a project (and generally 'reset' things) in Infinitest-Eclipse by cleaning the project.
+You can run all the tests in a project (and generally 'reset' things) in Infinitest-Eclipse by cleaning the project.  
 You can view the stack trace for a failure from the quick fix menu
 
-By default, IntelliJ does not compile classes automatically like Eclipse. You can obtain the same behaviour by checking the box "Make project automatically" in "Settings | Compiler". This way, you tests will be executed automagically without having anything to do.
+By default, IntelliJ does not compile classes automatically like Eclipse. You can obtain the same behaviour by checking the box "Make project automatically" in "Settings > Compiler". This way, you tests will be executed automagically without having anything to do.
 
 ## Common Problems
 

--- a/_posts/2013-04-18-user_guide.markdown
+++ b/_posts/2013-04-18-user_guide.markdown
@@ -66,7 +66,7 @@ If you need to set custom JVM options (such as memory settings, system propertie
 ## Pro Tips
 
 You can run all the tests in a project (and generally 'reset' things) in Infinitest-Eclipse by cleaning the project.  
-You can view the stack trace for a failure from the quick fix menu
+You can view the stack trace for a failure from the quick fix menu.
 
 By default, IntelliJ does not compile classes automatically like Eclipse. You can obtain the same behaviour by checking the box "Make project automatically" in "Settings > Compiler". This way, you tests will be executed automagically without having anything to do.
 
@@ -76,11 +76,11 @@ By default, IntelliJ does not compile classes automatically like Eclipse. You ca
 
 If you're running Eclipse, ensure that:
 
-You've resolved any compiler or other workspace errors
-The "Continuously Test" option in the Infinitest preferences (under Window->Preferences) is checked
-"Build Automatically" under the "Project" menu is checked
-The test is not being filtered by an entry in the `infinitest.filters` file in the root directory of the project
-If you're using a custom builder (like AspectJ) make sure you have the appropriate plugins installed
+You've resolved any compiler or other workspace errors.
+The "Continuously Test" option in the Infinitest preferences (under Window->Preferences) is checked.
+"Build Automatically" under the "Project" menu is checked.
+The test is not being filtered by an entry in the `infinitest.filters` file in the root directory of the project.
+If you're using a custom builder (like AspectJ) make sure you have the appropriate plugins installed.
 
 If you're using IntelliJ:
 

--- a/_posts/2013-04-18-user_guide.markdown
+++ b/_posts/2013-04-18-user_guide.markdown
@@ -65,10 +65,10 @@ If you need to set custom JVM options (such as memory settings, system propertie
 
 ## Pro Tips
 
-You can run all the tests in a project (and generally 'reset' things) in Infinitest-Eclipse by cleaning the project.  
+You can run all the tests in a project (and generally 'reset' things) in Infinitest-Eclipse by cleaning the project.
 You can view the stack trace for a failure from the quick fix menu
 
-By default, IntelliJ does not compile classes automatically like Eclipse. You can obtain the same behaviour by checking the box "Make project automatically" in "Settings > Compiler". This way, you tests will be executed automagically without having anything to do.
+By default, IntelliJ does not compile classes automatically like Eclipse. You can obtain the same behaviour by checking the box "Make project automatically" in "Settings | Compiler". This way, you tests will be executed automagically without having anything to do.
 
 ## Common Problems
 

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ title: Infinitest
       </p>
 
       <p class="lead">
-        You love TDD? You'll love Infinitest. You prefer "Test Last", take a shot too, you might fall in love as
+        You love TDD, BDD, or Specification By Example? You'll love Infinitest. You prefer "Test Last", take a shot too, you might fall in love as
         well!
       </p>
     </div>


### PR DESCRIPTION
In Pro Tips two sentences were not being separated properly, and the vertical bar was causing a sentence to render as a two column table.

Following the recommendations for Git's flavor of Markdown, I added two spaces to the end of the first sentence. I also modified the sentence using a vertical bar to describe menu navigation (Compiler | Settings) to use the -> notation used near the end of the user guide; getting rid of the confusing two column table and increased internal consistency of the document.

Having issues with Git and branching. You only need to use the changes in the last commit, "Fixed display problems due to Git's Markdown" to fix this issue. The rest is either in a separate pull request, or can be safely ignored.