### PR TITLE
Typo / Added example for infinitest.args.md

### DIFF
--- a/_doc/config/infinitest.args.md
+++ b/_doc/config/infinitest.args.md
@@ -9,4 +9,14 @@ Infinitest allows to configure JVM options (such as memory settings, system prop
 This is done through the infinitest.args file.
 This file is a simple text file that contains one VM argument per line to be included whenever Infinitest runs tests. 
 
-By default, Infinitest sets a maximum heap size of 256mb. You can override that by setting e.g. ``-mx512m`` (for twice the heap space). 
+By default, Infinitest sets a maximum heap size of 256mb. You can override that by setting e.g. ``-Xmx512m`` (for twice the heap space).
+
+## Example
+
+```
+-Xmx512m
+-Djavax.net.ssl.trustStore="C:\Users\user11\mycacerts.jks"
+-Djavax.net.ssl.trustStorePassword=changeit
+-Djavax.net.ssl.keyStore="C:\Users\user11\mykeys.jks"
+-Djavax.net.ssl.keyStorePassword=mypass
+```


### PR DESCRIPTION
Typo -xm -> -Xmx fixed
Added some explicit examples how to set different properties for the JVM line by line.